### PR TITLE
fix: personen_id nicht an erledigte Anrufe weitergeben

### DIFF
--- a/src/calls.php
+++ b/src/calls.php
@@ -59,6 +59,7 @@ function getDoneCallArray() {
 					'betreff'     => $row['call_subject'],
 					'bemerkungen' => $row['call_notes'],
 					'ersteller'   => getUserData(['id' => $row['create_person']])['name'],
+					'personen_id' => getAssignedUserIDs($row['id']),
 					'personen'    => getAssignedUserNames($row['id'])
 				);
 			}


### PR DESCRIPTION
Du hattest beim Fixen nur die Zeile vergessen, evtl könntest du da auch diesen und deinen fix commit zusammenziehen.
